### PR TITLE
Add @tool annotation to ComputeHelper

### DIFF
--- a/addons/compute-shader-plus/compute-helper.gd
+++ b/addons/compute-shader-plus/compute-helper.gd
@@ -1,3 +1,4 @@
+@tool
 extends Object
 class_name ComputeHelper
 ## Responsible for creating and running compute shaders.


### PR DESCRIPTION
Fixes #1 by adding the @tool annotation to the ComputeHelper script. It appears like static vars need @tool to work in editor, but static funcs and const vars don't. I'm not entirely sure why, but this PR should fix it.