### PR TITLE
Add TEXTURE_USAGE_CAN_COPY_FROM_BIT to the default texture format

### DIFF
--- a/addons/compute_shader_plus/image_format_helper.gd
+++ b/addons/compute_shader_plus/image_format_helper.gd
@@ -63,6 +63,7 @@ static func create_rd_texture_format(format: Image.Format, resolution: Vector2i)
 	texture_format.usage_bits = (
 		RenderingDevice.TEXTURE_USAGE_SAMPLING_BIT +
 		RenderingDevice.TEXTURE_USAGE_STORAGE_BIT +
-		RenderingDevice.TEXTURE_USAGE_CAN_UPDATE_BIT
+		RenderingDevice.TEXTURE_USAGE_CAN_UPDATE_BIT +
+		RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT
 	)
 	return texture_format


### PR DESCRIPTION
Fixes #4.