### PR TITLE
Fix example fill color

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Here's a simple example of a shader that reads and then writes to a texture, mak
 
 ```gdscript
 var image := Image.create(image_size.x, image_size.y, false, Image.FORMAT_RGBAF)
-image.fill(Color.BLACK)
+image.fill(Color.RED)
 
 var compute_shader := ComputeHelper.create("res://compute-shader.glsl")
 var input_texture := ImageUniform.create(image)


### PR DESCRIPTION
I thought that the readme example did not work as I expected the color to change, however the compute shader converts to grayscale by averaging the values which for initial fill of black result in black, so I suggest using a starting color other than ones already having equal channel values.