### PR TITLE
Add UniformBufferUniform class to addons

### DIFF
--- a/addons/compute_shader_plus/uniforms/uniform_buffer_uniform.gd
+++ b/addons/compute_shader_plus/uniforms/uniform_buffer_uniform.gd
@@ -1,0 +1,28 @@
+extends StorageBufferUniform
+class_name UniformBufferUniform
+## [Uniform] corresponding to arbitrary data.
+
+## Returns a new UniformBufferUniform object using the given [param data].
+static func create(data: PackedByteArray) -> UniformBufferUniform:
+	var uniform := UniformBufferUniform.new()
+	uniform.storage_buffer_size = data.size()
+	uniform.storage_buffer = ComputeHelper.rd.uniform_buffer_create(uniform.storage_buffer_size, data)
+	return uniform
+
+## UniformBufferUniform's custom implementation of [method Uniform.get_rd_uniform].
+func get_rd_uniform(binding: int) -> RDUniform:
+	var uniform := RDUniform.new()
+	uniform.uniform_type = RenderingDevice.UNIFORM_TYPE_UNIFORM_BUFFER
+	uniform.binding = binding
+	uniform.add_id(storage_buffer)
+	return uniform
+
+## Updates the currently stored data to match the given [param data].
+func update_data(data: PackedByteArray) -> void:
+	if storage_buffer_size == data.size():
+		ComputeHelper.rd.buffer_update(storage_buffer, 0, storage_buffer_size, data)
+	else:
+		ComputeHelper.rd.free_rid(storage_buffer)
+		storage_buffer_size = data.size()
+		storage_buffer = ComputeHelper.rd.uniform_buffer_create(storage_buffer_size, data)
+		rid_updated.emit(self)


### PR DESCRIPTION
While using uniform blocks, I noticed that there isn't a corresponding class in the plugin, so I added a `UniformBufferUniform` class.